### PR TITLE
feat: keycloak v14 & v22 for testing IDP broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ oidc_credentials.conf
 .DS_Store
 docker/build-context/data
 *.swp
+.swo
 __pycache__/

--- a/common/etc/nginx/idp/oidc_idp.conf
+++ b/common/etc/nginx/idp/oidc_idp.conf
@@ -29,7 +29,7 @@ map $x_client_id $oidc_app_identifier {
 }
 
 map $oidc_app_identifier $idp_domain {
-    default host.docker.internal:8443/realms/master/protocol/openid-connect;
+    default host.docker.internal:8443/auth/realms/master/protocol/openid-connect;
 }
 
 map $oidc_app_identifier $oidc_authz_endpoint {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,39 @@ networks:
 
 services:
 
+  # IdP for simulating OIDC/SSO w/ Keycloak 14
   keycloak:
     container_name: keycloak
-    image: quay.io/keycloak/keycloak:24.0.2
+    image: quay.io/keycloak/keycloak:14.0.0 # 24.0.0 for testing new version
     ports:
       - 8443:8443
     volumes:
       - ./myconfig/certs/oidc_simulator.crt:/etc/x509/https/tls.crt
       - ./myconfig/certs/oidc_simulator.key:/etc/x509/https/tls.key
     environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: password
+      KEYCLOAK_HOST: host.docker.internal
+      KEYCLOAK_HTTPS: true
+      HTTPS_PORT: 8443
+      KC_HOSTNAME: host.docker.internal
+      KC_HTTPS_CERTIFICATE_FILE: /etc/x509/https/tls.crt
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /etc/x509/https/tls.key
+    networks:
+      - mynetwork
+
+  # IdP for simulating OIDC/SSO from Keycloak 14 IdP Broker to Keycloak 24
+  keycloak24:
+    container_name: keycloak24
+    image: quay.io/keycloak/keycloak:24.0.0
+    ports:
+      - 10024:8443
+    volumes:
+      - ./myconfig/certs/oidc_simulator.crt:/etc/x509/https/tls.crt
+      - ./myconfig/certs/oidc_simulator.key:/etc/x509/https/tls.key
+    environment:
       KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN_PASSWORD: password
       KC_HOSTNAME: host.docker.internal
       KC_HTTPS_CERTIFICATE_FILE: /etc/x509/https/tls.crt
       KC_HTTPS_CERTIFICATE_KEY_FILE: /etc/x509/https/tls.key

--- a/myconfig/settings-cognito.env
+++ b/myconfig/settings-cognito.env
@@ -8,7 +8,7 @@ OIDC_SIMULATOR_KEY=oidc_simulator.key
 
 IDP_CLIENT_ID=my-client-id
 IDP_CLIENT_SECRET=${IDP_CLIENT_SECRET}
-IDP_WELL_KNOWN_ENDPOINTS=https://host.docker.internal:8443/auth/realms/master/.well-known/openid-configuration
+IDP_WELL_KNOWN_ENDPOINTS=https://cognito-idp.<region>.amazonaws.com/<user_pool_id>/.well-known/openid-configuration
 
 # The following endpoints are disregarded if IDP_WELL_KNOWN_ENDPOINTS isn't empty
 IDP_AUTHORIZATION_ENDPOINT=
@@ -19,4 +19,4 @@ IDP_USER_INFO_ENDPOINT=
 
 IDP_SCOPES="openid+profile+email"
 IDP_PKCE_ENABLE=true
-IDP_DNS_RESOLVER=127.0.0.11
+IDP_DNS_RESOLVER=8.8.8.8

--- a/myconfig/settings-kc-idp-broker.env
+++ b/myconfig/settings-kc-idp-broker.env
@@ -8,7 +8,7 @@ OIDC_SIMULATOR_KEY=oidc_simulator.key
 
 IDP_CLIENT_ID=my-client-id
 IDP_CLIENT_SECRET=${IDP_CLIENT_SECRET}
-IDP_WELL_KNOWN_ENDPOINTS=https://host.docker.internal:8443/auth/realms/master/.well-known/openid-configuration
+IDP_WELL_KNOWN_ENDPOINTS=https://host.docker.internal:10014/auth/realms/master/.well-known/openid-configuration
 
 # The following endpoints are disregarded if IDP_WELL_KNOWN_ENDPOINTS isn't empty
 IDP_AUTHORIZATION_ENDPOINT=


### PR DESCRIPTION
- Default Keycloak version with 14
- Add Keycloak v21
- Add AWS Cognito well-known endpoint